### PR TITLE
Add linkSelector option for router

### DIFF
--- a/lib/client/router.js
+++ b/lib/client/router.js
@@ -71,8 +71,11 @@ CarbonRouter = (function()
                     data: {}
                 }
             },
-            autoLoad: true
+            autoLoad: true,
+            linkSelector: 'a'
         };
+
+        this.updateTemplateEvents();
     }
 
 
@@ -82,7 +85,20 @@ CarbonRouter = (function()
      */
     CarbonRouter.prototype.configure = function(config) {
         _.extend(this._config, config);
+
+        this.updateTemplateEvents();
     };
+
+
+    /**
+     * Update template events
+     */
+    CarbonRouter.prototype.updateTemplateEvents = function() {
+        var linkSelector = this.getConfig('linkSelector'),
+            events = Template.carbon__region_layout.events = {};
+
+        events['click ' + linkSelector] = ClientUtil.handleClick;
+    }
 
 
     /**
@@ -262,4 +278,3 @@ CarbonRouter = (function()
 
     return CarbonRouter;
 })();
-

--- a/lib/client/template.js
+++ b/lib/client/template.js
@@ -12,18 +12,9 @@ Template.carbon__region.helpers({
 });
 
 
-Template.carbon__region_layout.events = {
-    "click a": function(ev) {
-        var href = ev.currentTarget.href;
-        if (ClientUtil.isRelativeHref(href)) {
-            ev.preventDefault();
-            Router.goUrl(href);
-        }
-    }
-};
+Template.carbon__region_layout.events = {};
 
 
 UI.registerHelper('carbonUrl', function(name, options) {
     return Router.url(name, options.hash);
 });
-

--- a/lib/client/util.js
+++ b/lib/client/util.js
@@ -13,3 +13,10 @@ ClientUtil.isRelativeHref = function(href) {
 };
 
 
+ClientUtil.handleClick = function(ev) {
+    var href = ev.currentTarget.href;
+    if (ClientUtil.isRelativeHref(href)) {
+        ev.preventDefault();
+        Router.goUrl(href);
+    }
+};

--- a/package.js
+++ b/package.js
@@ -39,4 +39,3 @@ Package.onTest(function (api) {
     api.addFiles('test/client/controller.js', 'client');
     api.addFiles('test/client/router.js', 'client');
 });
-

--- a/test/client/router.js
+++ b/test/client/router.js
@@ -10,6 +10,7 @@ Tinytest.add('#CarbonRouter - Default configuration values', function(test) {
     var router = new CarbonRouter();
     router.configure({});
     test.equal(router.getConfig('autoLoad'), true, 'Default config value for autoLoad is true.');
+    test.equal(router.getConfig('linkSelector'), 'a', 'Default config value for linkSelector is a.');
 
     var regionsConfig = router.getConfig('regions');
     test.equal(regionsConfig.layout.template, 'carbon__default_layout', 'Default config value for layout region template.');
@@ -30,6 +31,23 @@ Tinytest.add('#CarbonRouter - Add and match routes', function(test) {
     test.isNotNull(router.matchUrl('/prefix/123'), 'Use single parameter.');
     test.isNotNull(router.matchUrl('/prefix-123/456'), 'Use multiple parameters.');
     test.isNull(router.matchUrl('/prefix-/456'), 'Empty parameter value does not match.');
+});
+
+Tinytest.add('#CarbonRouter - Add default template events', function(test) {
+    var router = new CarbonRouter();
+
+    // TinyTest isFunction failing
+    test.isTrue(_.isFunction(Template.carbon__region_layout.events['click a']), 'Default event handler has not been created');
+});
+
+Tinytest.add('#CarbonRouter - Change template events', function(test) {
+    var router = new CarbonRouter();
+
+    router.configure({linkSelector: 'a:not(skip-router)'});
+
+    test.isUndefined(Template.carbon__region_layout.events['click a'], 'Old event handler has not been removed');
+    // TinyTest isFunction failing
+    test.isTrue(_.isFunction(Template.carbon__region_layout.events['click a:not(skip-router)']), 'New event handler has not been created');
 });
 
 
@@ -189,5 +207,3 @@ Tinytest.add('#CarbonRouter - Before hook', function(test) {
     test.isTrue(beforeHookIsCalled, 'Before hook is run.');
     test.isTrue(parameterIsPassedToBeforeHook, 'Parameter is passed to before hook.');
 });
-
-


### PR DESCRIPTION
The current version of carbon-router does not support specifying a selector for links need to be handled by the router. This pull request adds this feature.

Example:
After configuring the `linkSelector`
`Router.configure({linkSelector: 'a:not([skip-router])'});`
this link will not be handled by the router
`<a href='/something' skip-router>something</a>`
